### PR TITLE
feat: implemented feature to disable introspection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,15 @@ import Schema from 'schema/index.gql';
 import { PORT, isProd } from 'constants/index';
 import GraphQLFastify from 'server';
 
-const app = new GraphQLFastify({
+const { app } = new GraphQLFastify({
+  debug: !isProd,
   schema: makeExecutableSchema({
     typeDefs: buildSchema(Schema),
     resolvers,
   }),
-  debug: !isProd,
+  playground: {
+    introspection: !isProd,
+  },
 });
 
 app.listen(+PORT, () => {

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,4 +1,5 @@
 import { GraphQLSchema } from 'graphql';
+import { RenderPageOptions } from 'graphql-playground-html';
 import { ObjectOfAny } from './misc';
 
 export type GraphQLBody = {
@@ -7,11 +8,14 @@ export type GraphQLBody = {
   variables?: { [key: string]: ObjectOfAny };
 };
 
+type PlaygroundOptions = RenderPageOptions & {
+  enabled?: boolean;
+  endpoint?: string;
+  introspection?: boolean;
+};
+
 export type GraphQLFastifyConfig = {
   schema: GraphQLSchema;
   debug?: boolean;
-  playground?: {
-    enabled?: boolean;
-    endpoint?: string;
-  };
+  playground?: PlaygroundOptions;
 };


### PR DESCRIPTION
This PR implements the feature to disable the introspection from the playground.
To activate this protection you just need to send the flag `playground.introspection: false` to `GraphQLFastify` configuration